### PR TITLE
Display an error if a line does not exist

### DIFF
--- a/blametrail.py
+++ b/blametrail.py
@@ -80,7 +80,13 @@ def blame_trail(origfn, ui, repo, *pats, **opts):
     lines = fctx.annotate(follow=follow, linenumber=linenumber,
                           diffopts=diffopts)
 
-    metadata, line_contents = lines[trail_line - 1]
+    try:
+        metadata, line_contents = lines[trail_line - 1]
+    except IndexError:
+        ui.warn("Could not retrieve contents of line %r, IndexError.\n" %
+                (trail_line - 1))
+        return 1
+
     original_rev = metadata[0].rev()
     original_line = metadata[1]
 


### PR DESCRIPTION
Following up on #2 (which must or should be applied before), this fix outputs a warning if the line requested is not available.